### PR TITLE
Fix: Uncomment file_id generation in upload_file to resolve NameError (closes #2)

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ async def upload_file(file: UploadFile = File(...)):
     """
     try:
         # Generate unique file ID
-        # file_id = str(uuid.uuid4())
+        file_id = str(uuid.uuid4())
         
         # Get original filename
         original_filename = file.filename


### PR DESCRIPTION
This PR fixes the critical bug where all POST /upload requests failed with a NameError due to the file_id generation logic being commented out in main.py.

- Restores file_id generation using uuid4
- Ensures all references to file_id are valid
- Closes #2

Please review and merge to restore upload functionality.