### PR TITLE
Fix upload endpoint: Restore file_id generation to resolve NameError

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ async def upload_file(file: UploadFile = File(...)):
     """
     try:
         # Generate unique file ID
-        # file_id = str(uuid.uuid4())
+        file_id = str(uuid.uuid4())
         
         # Get original filename
         original_filename = file.filename


### PR DESCRIPTION
This pull request fixes the critical bug in the upload endpoint (`POST /upload`) where all file uploads failed due to `file_id` being undefined. The root cause was the file_id generation code being commented out. This PR restores the line:

```python
file_id = str(uuid.uuid4())
```

This ensures unique file IDs are generated for each upload, resolving the NameError and restoring upload functionality.

Closes #4.