### PR TITLE
Fix: Uncomment file_id generation to resolve upload endpoint failure (NameError)

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ async def upload_file(file: UploadFile = File(...)):
     """
     try:
         # Generate unique file ID
-        # file_id = str(uuid.uuid4())
+        file_id = str(uuid.uuid4())
         
         # Get original filename
         original_filename = file.filename


### PR DESCRIPTION
This PR fixes a critical bug where all POST /upload requests failed due to file_id not being defined. The line responsible for generating file_id was commented out, causing a NameError and breaking all file uploads.

- Uncommented file_id generation: `file_id = str(uuid.uuid4())`
- Restores upload functionality and resolves all related 500 errors.

Closes #6.

Please review and merge promptly as this blocks all file uploads.