### PR TITLE
DEvv

### DIFF
--- a/main.py
+++ b/main.py
@@ -230,7 +230,7 @@ async def upload_file(
     """
     try:
         # Generate unique file ID
-        # file_id = str(uuid.uuid4())
+        file_id = str(uuid.uuid4())
         
         # Get original filename
         original_filename = file.filename
@@ -300,7 +300,7 @@ async def root():
         "message": "File Upload API with Authentication",
         "endpoints": {
             "/login": "POST - Login and get access token",
-            "/logout": "POST - Logout (requires authentication) - ⚠️ BUGGY",
+            "/logout": "POST - Logout (requires authentication) -  BUGGY",
             "/users/me": "GET - Get current user info (requires authentication)",
             "/upload": "POST - Upload a file (requires authentication)",
             "/get_files": "GET - Get all uploaded files (requires authentication)",


### PR DESCRIPTION
This PR fixes the `NameError` in the upload functionality by uncommenting the line that generates `file_id`.

**Changes include:**
- Uncommented the line responsible for generating a unique `file_id` in the `/upload` endpoint.

**Issue Fixed:** [#36](https://github.com/anushaupadya7/test_backend/issues/36)