### PR TITLE
Fix NameError in upload_file function - 11-12-2025-083447-5f3c3b

### DIFF
--- a/main.py
+++ b/main.py
@@ -230,7 +230,7 @@ async def upload_file(
     """
     try:
         # Generate unique file ID
-        # file_id = str(uuid.uuid4())
+        file_id = str(uuid.uuid4())
         
         # Get original filename
         original_filename = file.filename

--- a/main.py
+++ b/main.py
@@ -228,10 +228,10 @@ async def upload_file(
     Requires authentication.
     Returns the file ID and filename.
     """
+    # Generate unique file ID
+    file_id = str(uuid.uuid4())
+
     try:
-        # Generate unique file ID
-        file_id = str(uuid.uuid4())
-        
         # Get original filename
         original_filename = file.filename
         


### PR DESCRIPTION
This pull request resolves the NameError occurring in the upload_file function by uncommenting the line responsible for generating the file_id. Closes #208